### PR TITLE
Update PayFast IP address whitelisting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,8 @@ If your web server is behind reverse proxy you should also specify
 (default is 'REMOTE_ADDR').
 
 There is an option with PayFast server IP addresses (``PAYFAST_IP_ADDRESSES``).
-It is a list with current PayFast servers' ip addresses. If they will
-change then override this option in your settings.py.
+It is a list with current PayFast servers' IP host / network addresses.
+If they will change then override this option in your settings.py.
 
 You also have to setup your PayFast account on payfast.co.za. Login into the
 admin panel, go to 'My Account -> Integration', enable the Instant Transaction

--- a/payfast/conf.py
+++ b/payfast/conf.py
@@ -32,4 +32,8 @@ USE_POSTBACK = getattr(settings, 'PAYFAST_USE_POSTBACK', True)
 
 # request.META key with client ip address
 IP_HEADER = getattr(settings, 'PAYFAST_IP_HEADER', 'REMOTE_ADDR')
-IP_ADDRESSES = getattr(settings, 'PAYFAST_IP_ADDRESSES', ['196.33.227.224', '196.33.227.225'])
+
+DEFAULT_PAYFAST_IP_ADDRESSES = [
+    '196.33.227.224',
+    '196.33.227.225',
+]

--- a/payfast/conf.py
+++ b/payfast/conf.py
@@ -33,7 +33,9 @@ USE_POSTBACK = getattr(settings, 'PAYFAST_USE_POSTBACK', True)
 # request.META key with client ip address
 IP_HEADER = getattr(settings, 'PAYFAST_IP_HEADER', 'REMOTE_ADDR')
 
+# Reference: https://developers.payfast.co.za/documentation/#ip-addresses
+# The values below are current as of 2017 December.
 DEFAULT_PAYFAST_IP_ADDRESSES = [
-    '196.33.227.224',
-    '196.33.227.225',
+    '197.97.145.144/28',
+    '41.74.179.192/27',
 ]

--- a/payfast/forms.py
+++ b/payfast/forms.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from ipaddress import ip_address, ip_network
 
 from six.moves.urllib_parse import urljoin
 
@@ -158,9 +159,12 @@ def is_payfast_ip_address(ip_address_str):
     :type ip_address_str: str
     :rtype: bool
     """
+    # TODO: Django system check for validity?
     payfast_ip_addresses = getattr(settings, 'PAYFAST_IP_ADDRESSES',
                                    conf.DEFAULT_PAYFAST_IP_ADDRESSES)
-    return ip_address_str in payfast_ip_addresses
+
+    return any(ip_address(ip_address_str) in ip_network(payfast_address)
+               for payfast_address in payfast_ip_addresses)
 
 
 class NotifyForm(forms.ModelForm):

--- a/payfast/forms.py
+++ b/payfast/forms.py
@@ -149,6 +149,20 @@ class PayFastForm(HiddenForm):
         self._signature = self.fields['signature'].initial = signature(data)
 
 
+def is_payfast_ip_address(ip_address_str):
+    """
+    Return True if ip_address_str matches one of PayFast's server IP addresses.
+
+    Setting: `PAYFAST_IP_ADDRESSES`
+
+    :type ip_address_str: str
+    :rtype: bool
+    """
+    payfast_ip_addresses = getattr(settings, 'PAYFAST_IP_ADDRESSES',
+                                   conf.DEFAULT_PAYFAST_IP_ADDRESSES)
+    return ip_address_str in payfast_ip_addresses
+
+
 class NotifyForm(forms.ModelForm):
 
     def __init__(self, request, *args, **kwargs):
@@ -159,7 +173,7 @@ class NotifyForm(forms.ModelForm):
 
     def clean(self):
         self.ip = self.request.META.get(conf.IP_HEADER, None)
-        if self.ip not in conf.IP_ADDRESSES:
+        if not is_payfast_ip_address(self.ip):
             raise forms.ValidationError('untrusted ip: %s' % self.ip)
 
         # Verify signature

--- a/payfast/forms.py
+++ b/payfast/forms.py
@@ -1,3 +1,4 @@
+import sys
 from collections import OrderedDict
 from ipaddress import ip_address, ip_network
 
@@ -162,6 +163,13 @@ def is_payfast_ip_address(ip_address_str):
     # TODO: Django system check for validity?
     payfast_ip_addresses = getattr(settings, 'PAYFAST_IP_ADDRESSES',
                                    conf.DEFAULT_PAYFAST_IP_ADDRESSES)
+
+    if sys.version_info < (3,):
+        # Python 2 usability: Coerce str to unicode, to avoid very common TypeErrors.
+        # (On Python 3, this should generally not happen:
+        #  let unexpected bytes values fail as expected.)
+        ip_address_str = unicode(ip_address_str)  # noqa: F821
+        payfast_ip_addresses = [unicode(address) for address in payfast_ip_addresses]  # noqa: F821
 
     return any(ip_address(ip_address_str) in ip_network(payfast_address)
                for payfast_address in payfast_ip_addresses)

--- a/payfast/tests.py
+++ b/payfast/tests.py
@@ -6,6 +6,7 @@ import unittest
 from collections import OrderedDict
 
 import django
+from django.conf import settings
 from django.test import TestCase, SimpleTestCase, override_settings
 
 from payfast.forms import notify_url, PayFastForm, NotifyForm, is_payfast_ip_address
@@ -181,3 +182,13 @@ class IPTest(SimpleTestCase):
         self.assertFalse(is_payfast_ip_address('41.74.179.194'))
         self.assertTrue(is_payfast_ip_address('196.33.227.224'))
         self.assertTrue(is_payfast_ip_address('196.33.227.225'))
+
+    @override_settings(PAYFAST_IP_ADDRESSES=['196.33.227.224/31'])
+    def test_more_servers_masked(self):
+        self.assertFalse(is_payfast_ip_address('127.0.0.1'))
+        self.assertFalse(is_payfast_ip_address('41.74.179.194'))
+
+        self.assertFalse(is_payfast_ip_address('196.33.227.223'))
+        self.assertTrue(is_payfast_ip_address('196.33.227.224'))
+        self.assertTrue(is_payfast_ip_address('196.33.227.225'))
+        self.assertFalse(is_payfast_ip_address('196.33.227.226'))

--- a/payfast/tests.py
+++ b/payfast/tests.py
@@ -192,3 +192,22 @@ class IPTest(SimpleTestCase):
         self.assertTrue(is_payfast_ip_address('196.33.227.224'))
         self.assertTrue(is_payfast_ip_address('196.33.227.225'))
         self.assertFalse(is_payfast_ip_address('196.33.227.226'))
+
+    @override_settings(PAYFAST_IP_ADDRESSES=[])
+    def test_default_ip_addresses(self):
+        del settings.PAYFAST_IP_ADDRESSES
+
+        self.assertFalse(is_payfast_ip_address('127.0.0.1'))
+        self.assertFalse(is_payfast_ip_address('196.33.227.224'))
+
+        # Default PayFast range: 197.97.145.144/28
+        self.assertFalse(is_payfast_ip_address('197.97.145.143'))
+        self.assertTrue(all(is_payfast_ip_address('197.97.145.{}'.format(n))
+                            for n in range(144, 160)))
+        self.assertFalse(is_payfast_ip_address('197.97.145.160'))
+
+        # Default PayFast range: 41.74.179.192/27
+        self.assertFalse(is_payfast_ip_address('41.74.179.191'))
+        self.assertTrue(all(is_payfast_ip_address('41.74.179.{}'.format(n))
+                            for n in range(192, 224)))
+        self.assertFalse(is_payfast_ip_address('41.74.179.225'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 # https://pycodestyle.readthedocs.io/en/latest/intro.html#configuration
 [pycodestyle]
 exclude = .eggs,.tox,build,migrations

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
+import sys
 from setuptools import setup, find_packages
 
 
 def README():
     with open('README.rst') as f:
         return f.read()
+
+
+_PYTHON_2_BACKPORTS = ['ipaddress'] if sys.version_info < (3,) else []
 
 
 setup(
@@ -22,7 +26,7 @@ setup(
     install_requires=[
         'six',
         'Django',
-    ],
+    ] + _PYTHON_2_BACKPORTS,
 
     url='https://github.com/pjdelport/django-payfast',
     license='MIT license',
@@ -35,7 +39,8 @@ setup(
         'Framework :: Django',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ),
 )


### PR DESCRIPTION
This enhances `PAYFAST_IP_ADDRESSES` to allow specifying networks, and updates the default values ([PayFast docs](https://developers.payfast.co.za/documentation/#ip-addresses)) to reflect PayFast's current server addresses (which are given as network ranges, no longer individual hosts).