### PR TITLE
Fix support for a custom user model in the foreign key

### DIFF
--- a/payfast/models.py
+++ b/payfast/models.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import six
 from django.db import models
-from django.contrib.auth.models import User
+from django.conf import settings
 from django.utils.encoding import python_2_unicode_compatible
 
 from payfast import readable_models
@@ -55,7 +55,7 @@ class PayFastOrder(six.with_metaclass(readable_models.ModelBase, models.Model)):
     request_ip = models.GenericIPAddressField(null=True, blank=True)
     debug_info = models.CharField(max_length=255, null=True, blank=True)
     trusted = models.NullBooleanField(default=None)
-    user = models.ForeignKey(User, null=True, blank=True, on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.CASCADE)
 
     class HelpText:
         m_payment_id = "Unique transaction ID on the receiver's system."

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ max-line-length = 100
 [flake8]
 exclude = .eggs,.tox,build,migrations
 max-line-length = 100
+
+[easy_install]
+zip_ok = False


### PR DESCRIPTION
This fixes the foreign key in the PayFastOrder model so that a custom user model can be used.
I also had issues running migrations from within the egg, so I prevented the zipping 