### PR TITLE
Better custom user model handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,17 @@ You also have to setup your PayFast account on payfast.co.za. Login into the
 admin panel, go to 'My Account -> Integration', enable the Instant Transaction
 Notification (ITN) and provide the Notify URL.
 
+When passing a user to `PayFastForm`, the form will by default look for the
+`first_name` and `last_name` fields on the user. If you're using a custom user
+model with different field names, you can customise how the fields are looked
+up by setting these callables::
+
+    PAYFAST_GET_USER_FIRST_NAME = lambda user: user.my_first_name()
+    PAYFAST_GET_USER_LAST_NAME = lambda user: user.my_last_name()
+
+Alternatively, set these to `None` to disable initialising the PayFast
+`name_first` and `name_last` fields from the user.
+
 Usage
 =====
 

--- a/payfast/conf.py
+++ b/payfast/conf.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from operator import attrgetter
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -41,3 +43,7 @@ DEFAULT_PAYFAST_IP_ADDRESSES = [
     '197.97.145.144/28',
     '41.74.179.192/27',
 ]
+
+
+GET_USER_FIRST_NAME = getattr(settings, 'PAYFAST_GET_USER_FIRST_NAME', attrgetter('first_name'))
+GET_USER_LAST_NAME = getattr(settings, 'PAYFAST_GET_USER_LAST_NAME', attrgetter('last_name'))

--- a/payfast/conf.py
+++ b/payfast/conf.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-from operator import attrgetter
-
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -43,7 +41,3 @@ DEFAULT_PAYFAST_IP_ADDRESSES = [
     '197.97.145.144/28',
     '41.74.179.192/27',
 ]
-
-
-GET_USER_FIRST_NAME = getattr(settings, 'PAYFAST_GET_USER_FIRST_NAME', attrgetter('first_name'))
-GET_USER_LAST_NAME = getattr(settings, 'PAYFAST_GET_USER_LAST_NAME', attrgetter('last_name'))

--- a/payfast/forms.py
+++ b/payfast/forms.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import sys
 from ipaddress import ip_address, ip_network
+from operator import attrgetter
 
 from django.contrib.auth import get_user_model
 from six import text_type as str
@@ -101,12 +102,16 @@ class PayFastForm(HiddenForm):
     signature = forms.CharField()
 
     def __init__(self, *args, **kwargs):
+        get_first_name = getattr(settings, 'PAYFAST_GET_USER_FIRST_NAME', attrgetter('first_name'))
+        get_last_name = getattr(settings, 'PAYFAST_GET_USER_LAST_NAME', attrgetter('last_name'))
+
         user = kwargs.pop('user', None)
         if user:
-            if conf.GET_USER_FIRST_NAME is not None:
-                kwargs['initial'].setdefault('name_first', conf.GET_USER_FIRST_NAME(user))
-            if conf.GET_USER_LAST_NAME is not None:
-                kwargs['initial'].setdefault('name_last', conf.GET_USER_LAST_NAME(user))
+
+            if get_first_name is not None:
+                kwargs['initial'].setdefault('name_first', get_first_name(user))
+            if get_last_name is not None:
+                kwargs['initial'].setdefault('name_last', get_last_name(user))
 
             # Django 1.11 adds AbstractBaseUser.get_email_field_name()
             email_address = (user.email if django.VERSION < (1, 11) else

--- a/payfast/forms.py
+++ b/payfast/forms.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import sys
 from ipaddress import ip_address, ip_network
 
+from django.contrib.auth import get_user_model
 from six import text_type as str
 from six.moves.urllib_parse import urljoin
 
@@ -104,7 +105,11 @@ class PayFastForm(HiddenForm):
         if user:
             kwargs['initial'].setdefault('name_first', user.first_name)
             kwargs['initial'].setdefault('name_last', user.last_name)
-            kwargs['initial'].setdefault('email_address', user.email)
+
+            # Django 1.11 adds AbstractBaseUser.get_email_field_name()
+            email_address = (user.email if django.VERSION < (1, 11) else
+                             getattr(user, get_user_model().get_email_field_name()))
+            kwargs['initial'].setdefault('email_address', email_address)
 
         kwargs['initial'].setdefault('notify_url', notify_url())
         kwargs['initial'].setdefault('merchant_id', conf.MERCHANT_ID)

--- a/payfast/forms.py
+++ b/payfast/forms.py
@@ -103,8 +103,10 @@ class PayFastForm(HiddenForm):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)
         if user:
-            kwargs['initial'].setdefault('name_first', user.first_name)
-            kwargs['initial'].setdefault('name_last', user.last_name)
+            if conf.GET_USER_FIRST_NAME is not None:
+                kwargs['initial'].setdefault('name_first', conf.GET_USER_FIRST_NAME(user))
+            if conf.GET_USER_LAST_NAME is not None:
+                kwargs['initial'].setdefault('name_last', conf.GET_USER_LAST_NAME(user))
 
             # Django 1.11 adds AbstractBaseUser.get_email_field_name()
             email_address = (user.email if django.VERSION < (1, 11) else

--- a/payfast/tests.py
+++ b/payfast/tests.py
@@ -61,6 +61,66 @@ class PayFastFormTest(TestCase):
         }, form.initial)
         self.assertEqual(user, form.order.user)
 
+    @override_settings(
+        PAYFAST_GET_USER_FIRST_NAME=lambda user: user.username + ' First Name',
+        PAYFAST_GET_USER_LAST_NAME=lambda user: user.username + ' Last Name',
+    )
+    def test_init_with_user_custom_names(self):
+        user = User.objects.create(
+            username='example_user',
+            email='user@example.com',
+            first_name='First',
+            last_name='Last',
+        )
+        form = PayFastForm(
+            initial={
+                'amount': 100,
+                'item_name': 'Example item',
+            },
+            user=user
+        )
+        self.assertEqual({
+            'amount': 100,
+            'email_address': 'user@example.com',
+            'item_name': 'Example item',
+            'm_payment_id': '1',
+            'merchant_id': '10000100',
+            'merchant_key': '46f0cd694581a',
+            'name_first': 'example_user First Name',
+            'name_last': 'example_user Last Name',
+            'notify_url': notify_url(),
+        }, form.initial)
+        self.assertEqual(user, form.order.user)
+
+    @override_settings(
+        PAYFAST_GET_USER_FIRST_NAME=None,
+        PAYFAST_GET_USER_LAST_NAME=None,
+    )
+    def test_init_with_user_custom_names_disabled(self):
+        user = User.objects.create(
+            username='example_user',
+            email='user@example.com',
+            first_name='First',
+            last_name='Last',
+        )
+        form = PayFastForm(
+            initial={
+                'amount': 100,
+                'item_name': 'Example item',
+            },
+            user=user
+        )
+        self.assertEqual({
+            'amount': 100,
+            'email_address': 'user@example.com',
+            'item_name': 'Example item',
+            'm_payment_id': '1',
+            'merchant_id': '10000100',
+            'merchant_key': '46f0cd694581a',
+            'notify_url': notify_url(),
+        }, form.initial)
+        self.assertEqual(user, form.order.user)
+
 
 def _test_data():
     return OrderedDict([

--- a/payfast/tests.py
+++ b/payfast/tests.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 
 import django
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.test import TestCase, SimpleTestCase, override_settings
 
 from payfast import api
@@ -14,6 +15,51 @@ from payfast import conf
 from payfast.forms import notify_url, PayFastForm, is_payfast_ip_address
 from payfast.models import PayFastOrder
 import payfast.signals
+
+
+class PayFastFormTest(TestCase):
+
+    def test_init(self):
+        form = PayFastForm(initial={
+            'amount': 100,
+            'item_name': 'Example item',
+        })
+        self.assertEqual({
+            'amount': 100,
+            'item_name': 'Example item',
+            'm_payment_id': '1',
+            'merchant_id': '10000100',
+            'merchant_key': '46f0cd694581a',
+            'notify_url': notify_url(),
+        }, form.initial)
+        self.assertIsNone(form.order.user)
+
+    def test_init_with_user(self):
+        user = User.objects.create(
+            username='example_user',
+            email='user@example.com',
+            first_name='First',
+            last_name='Last',
+        )
+        form = PayFastForm(
+            initial={
+                'amount': 100,
+                'item_name': 'Example item',
+            },
+            user=user
+        )
+        self.assertEqual({
+            'amount': 100,
+            'email_address': 'user@example.com',
+            'item_name': 'Example item',
+            'm_payment_id': '1',
+            'merchant_id': '10000100',
+            'merchant_key': '46f0cd694581a',
+            'name_first': 'First',
+            'name_last': 'Last',
+            'notify_url': notify_url(),
+        }, form.initial)
+        self.assertEqual(user, form.order.user)
 
 
 def _test_data():


### PR DESCRIPTION
This avoids the existing hard dependency on the user model having `first_name` and `last_name` fields, and lets the project settings override how these fields are looked up.